### PR TITLE
fixing issue #10 with version

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -7,7 +7,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/concat",
-      "version_requirement": "\u003e1.0.0"
+      "version_requirement": ">= 1.0.0"
     }
   ],
   "types": [],


### PR DESCRIPTION
This pull request should fix the issue with r10k etc related to the bad characters in the metadata.json file.  This addresses issue #10 .

I have tested on my own r10k instance and it all seems to work fine.
